### PR TITLE
Symbol changes if type set after symbol

### DIFF
--- a/Upkeep-ios/Upkeep/Detail.swift
+++ b/Upkeep-ios/Upkeep/Detail.swift
@@ -80,6 +80,8 @@ struct Detail: View {
             }
             LabeledContent(Design.Appliance.typeLabel) {
                 TogglePicker(selection: $model.type)
+            }.onChange(of: model.type) {
+                model.symbol = model.type.symbol
             }
             LabeledContent(Design.Appliance.modelNumberLabel) {
                 ToggleTextField(text: $model.modelNumber)
@@ -139,6 +141,6 @@ enum Design {
     let container = try! ModelContainer(for: Appliance.self, Manual.self, configurations: .init(isStoredInMemoryOnly: true))
     let app = Appliance()
     container.mainContext.insert(app)
-    return Detail(model: app, type: .existing)
+    return Detail(model: app, type: .new)
         .modelContainer(container)
 }

--- a/Upkeep-ios/Upkeep/Item.swift
+++ b/Upkeep-ios/Upkeep/Item.swift
@@ -10,14 +10,13 @@ import SwiftData
 import SwiftUI
 
 struct ItemSymbol: View {
-    let symbol: String
-    let color: Color
+    @Bindable var appliance: Appliance
 
     var body: some View {
         ZStack {
             Rectangle()
-                .fill(color.gradient)
-            Image(systemName: symbol)
+                .fill(appliance.brand.rawValue.hashedToColor().gradient)
+            appliance.symbol.image
                 .resizable()
                 .symbolVariant(.fill)
                 .foregroundStyle(.white)
@@ -35,10 +34,10 @@ struct Item: View {
 
     var body: some View {
         HStack(spacing: 20) {
-            ItemSymbol(symbol: appliance.symbol, color: appliance.brand.rawValue.hashedToColor())
+            ItemSymbol(appliance: appliance)
 
             VStack(alignment: .leading) {
-                Text(appliance.brand.rawValue)
+                Text(appliance.brand.formattedRawValue)
                     .font(.system(.caption, weight: .bold))
                     .textCase(.uppercase)
                     .foregroundStyle(.secondary)

--- a/Upkeep-ios/Upkeep/Models.swift
+++ b/Upkeep-ios/Upkeep/Models.swift
@@ -46,7 +46,7 @@ final class Appliance: Identifiable {
     var purchaseDate: Date
     var warrantyExpirationDate: Date
     var lastMaintenaceDate: Date
-    var symbol: String
+    var symbol: ApplianceSymbol
     var manuals: [Manual]
 
     init(name: String = "Refrigerator",
@@ -57,7 +57,7 @@ final class Appliance: Identifiable {
          purchaseDate: Date = Date(),
          warrantyExpirationDate: Date = Date(),
          lastMaintenaceDate: Date = Date(),
-         symbol: String = "refrigerator",
+         symbol: ApplianceSymbol? = nil,
          manuals: [Manual] = [Manual]())
     {
         self.name = name
@@ -68,7 +68,7 @@ final class Appliance: Identifiable {
         self.purchaseDate = purchaseDate
         self.warrantyExpirationDate = warrantyExpirationDate
         self.lastMaintenaceDate = lastMaintenaceDate
-        self.symbol = symbol
+        self.symbol = symbol != nil ? symbol! : type.symbol
         self.manuals = manuals
     }
 }
@@ -286,5 +286,100 @@ enum ApplianceSymbol: String, ApplianceEnumProtocol {
 
     var formattedRawValue: String {
         "Adherance to protocol ApplianceEnumProtocol not yet implemented"
+    }
+}
+
+extension ApplianceType {
+    var symbol: ApplianceSymbol {
+        switch self {
+        case .refrigerator:
+            return .refrigerator
+        case .oven:
+            return .oven
+        case .microwave:
+            return .microwave
+        case .dishwasher:
+            return .dishwasher
+        case .blender:
+            return .wrenchAndScrewdriverFill
+        case .toaster:
+            return .stove
+        case .coffeeMaker:
+            return .pc
+        case .foodProcessor:
+            return .display
+        case .mixer:
+            return .hifiSpeaker
+        case .electricKettle:
+            return .powerOutletTypeIFill
+        case .washingMachine:
+            return .washer
+        case .dryer:
+            return .dryer
+        case .iron:
+            return .wrenchAndScrewdriverFill
+        case .steamPress:
+            return .powerOutletTypeIFill
+        case .vacuumCleaner:
+            return .wrenchAndScrewdriverFill
+        case .steamCleaner:
+            return .videoProjector
+        case .carpetCleaner:
+            return .wrenchAndScrewdriverFill
+        case .floorPolisher:
+            return .wrenchAndScrewdriverFill
+        case .airConditioner:
+            return .airPurifier
+        case .heater:
+            return .verticalHeater
+        case .humidifier:
+            return .humidifier
+        case .dehumidifier:
+            return .dehumidifier
+        case .fan:
+            return .wrenchAndScrewdriverFill
+        case .airPurifier:
+            return .airPurifier
+        case .hairDryer:
+            return .wrenchAndScrewdriverFill
+        case .electricShaver:
+            return .wrenchAndScrewdriverFill
+        case .electricToothbrush:
+            return .wrenchAndScrewdriverFill
+        case .hairStraightener:
+            return .wrenchAndScrewdriverFill
+        case .curlingIron:
+            return .wrenchAndScrewdriverFill
+        case .television:
+            return .display
+        case .homeTheaterSystem:
+            return .hifiSpeaker
+        case .soundbar:
+            return .hifiSpeaker
+        case .dvdPlayer:
+            return .wrenchAndScrewdriverFill
+        case .gamingConsole:
+            return .gameController
+        case .computer:
+            return .pc
+        case .printer:
+            return .printer
+        case .scanner:
+            return .scanner
+        case .faxMachine:
+            return .faxMachine
+        case .garbageDisposal:
+            return .wrenchAndScrewdriverFill
+        case .waterHeater:
+            return .powerOutletTypeIFill
+        case .sewingMachine:
+            return .wrenchAndScrewdriverFill
+        case .electricFireplace:
+            return .powerOutletTypeIFill
+        case .electricBlanket:
+            return .wrenchAndScrewdriverFill
+        case .generic:
+            return .wrenchAndScrewdriverFill
+        }
     }
 }

--- a/Upkeep-ios/Upkeep/SymbolPicker.swift
+++ b/Upkeep-ios/Upkeep/SymbolPicker.swift
@@ -42,7 +42,7 @@ struct SymbolPicker: View {
                     ForEach(searchResults, id: \.self) { symbol in
                         Button(action: {
                             // Set selected symbol to the appliance and dismiss the view
-                            appliance.symbol = symbol.rawValue
+                            appliance.symbol = symbol
                             dismiss()
                         }) {
                             symbol.image

--- a/Upkeep-ios/Upkeep/SymbolPickerButton.swift
+++ b/Upkeep-ios/Upkeep/SymbolPickerButton.swift
@@ -16,7 +16,7 @@ struct SymbolPickerButton: View {
                 .fill(.background)
                 .aspectRatio(1, contentMode: .fit)
 
-            Image(systemName: appliance.symbol)
+            Image(systemName: appliance.symbol.rawValue)
                 .resizable()
                 .scaledToFit()
                 .symbolVariant(.fill)


### PR DESCRIPTION
This pull request introduces several changes to the `Upkeep-ios` Swift application primarily focusing on the handling of appliance symbols. The changes involve updates in the `Detail.swift`, `Item.swift`, `Models.swift`, `SymbolPicker.swift`, and `SymbolPickerButton.swift` files.

Handling of appliance symbols:

* [`Upkeep-ios/Upkeep/Detail.swift`](diffhunk://#diff-d47771b453fc599b0011a09b1c7f571242a0abc33e552bdc565d2e2aac2a99fdR83-R84): The `model.symbol` property is now updated whenever `model.type` changes. This ensures that the symbol always corresponds to the current type of the appliance.

* [`Upkeep-ios/Upkeep/Models.swift`](diffhunk://#diff-44436a243b8c5d2a9cc97a30e3c04b67eb15ab32dab97d47b42e71d1ca32de5eL49-R49): The `symbol` property in the `Appliance` class has been changed from `String` type to `ApplianceSymbol`. This introduces a more structured way of handling appliance symbols. If no symbol is supplied during initialization, the symbol corresponding to the appliance type is used by default. [[1]](diffhunk://#diff-44436a243b8c5d2a9cc97a30e3c04b67eb15ab32dab97d47b42e71d1ca32de5eL49-R49) [[2]](diffhunk://#diff-44436a243b8c5d2a9cc97a30e3c04b67eb15ab32dab97d47b42e71d1ca32de5eL60-R60) [[3]](diffhunk://#diff-44436a243b8c5d2a9cc97a30e3c04b67eb15ab32dab97d47b42e71d1ca32de5eL71-R71)

* [`Upkeep-ios/Upkeep/Models.swift`](diffhunk://#diff-44436a243b8c5d2a9cc97a30e3c04b67eb15ab32dab97d47b42e71d1ca32de5eR291-R385): An extension has been added to the `ApplianceType` enumeration that provides a corresponding `ApplianceSymbol` for each appliance type.

UI and display changes:

* [`Upkeep-ios/Upkeep/Item.swift`](diffhunk://#diff-157c90fb0571876d719da1c4bdd47b6bb42672693d86c0b74179b71b6fca3a6aL13-R19): The `ItemSymbol` and `Item` views now use the `appliance` object directly instead of its properties. This simplifies the code and makes it more robust to changes in the `Appliance` class. [[1]](diffhunk://#diff-157c90fb0571876d719da1c4bdd47b6bb42672693d86c0b74179b71b6fca3a6aL13-R19) [[2]](diffhunk://#diff-157c90fb0571876d719da1c4bdd47b6bb42672693d86c0b74179b71b6fca3a6aL38-R40)

* `Upkeep-ios/Upkeep/SymbolPicker.swift` and `Upkeep-ios/Upkeep/SymbolPickerButton.swift`: The symbol picker now uses the `ApplianceSymbol` enumeration instead of raw strings. This ensures consistency with the changes in the `Appliance` class. [[1]](diffhunk://#diff-a4610e5737a6f32bd61e14ce1b17e0ac07ebda09eaa15bbc4a25ab3e2b0c372dL45-R45) [[2]](diffhunk://#diff-58a3361b528b87880a571ceddd86488ccc1c0fc954b92a4403f197fdc986ef43L19-R19)

Miscellaneous changes:

* [`Upkeep-ios/Upkeep/Detail.swift`](diffhunk://#diff-d47771b453fc599b0011a09b1c7f571242a0abc33e552bdc565d2e2aac2a99fdL142-R144): The `Detail` view is now initialized with a new appliance type by default.