### PR TITLE
Symbol changes if type set after symbol

### DIFF
--- a/Upkeep-ios/Upkeep/Models.swift
+++ b/Upkeep-ios/Upkeep/Models.swift
@@ -50,7 +50,7 @@ final class Appliance: Identifiable {
     var manuals: [Manual]
 
     init(name: String = "Refrigerator",
-         type: ApplianceType = .refrigerator,
+         type: ApplianceType = ApplianceType.allCases.randomElement()!,
          brand: ApplianceBrand? = ApplianceBrand.allCases.randomElement()!,
          modelNumber: String? = "00000000",
          serialNumber: String? = "00000000",


### PR DESCRIPTION
This pull request introduces a change to the `Appliance` class in the `Models.swift` file. The change modifies the default value of the `type` property in the `init` method. Instead of always defaulting to `refrigerator`, the `type` property now gets a random value from all available `ApplianceType` cases.