### PR TITLE
added procfile

### DIFF
--- a/UpkeepWebService/Package.swift
+++ b/UpkeepWebService/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "UpkeepWebService",
     platforms: [
-       .macOS(.v13)
+        .macOS(.v13),
     ],
     dependencies: [
         // 💧 A server-side Swift web framework.
@@ -25,7 +25,7 @@ let package = Package(
                 .product(name: "XCTVapor", package: "vapor"),
             ],
             swiftSettings: swiftSettings
-        )
+        ),
     ]
 )
 

--- a/UpkeepWebService/Procfile
+++ b/UpkeepWebService/Procfile
@@ -1,0 +1,1 @@
+web: Run serve --env production --hostname 0.0.0.0 --port $PORT


### PR DESCRIPTION
This pull request primarily focuses on the `UpkeepWebService` package and its configuration. The most significant changes include the addition of a `Procfile` for web server configuration and minor syntax adjustments in the `Package.swift` file.

* [`UpkeepWebService/Package.swift`](diffhunk://#diff-01b54fabc476b496c23ef7f251649ea0df2bf6b0ca69eb195cac357825633721L7-R7): Two changes were made in this file. The first change is a minor syntax adjustment, adding a comma after the macOS platform version [[1]](diffhunk://#diff-01b54fabc476b496c23ef7f251649ea0df2bf6b0ca69eb195cac357825633721L7-R7). The second change is another minor syntax adjustment, adding a comma after the `swiftSettings` [[2]](diffhunk://#diff-01b54fabc476b496c23ef7f251649ea0df2bf6b0ca69eb195cac357825633721L28-R28).
* [`UpkeepWebService/Procfile`](diffhunk://#diff-1ae643ac21fff7924581b5325d6b2fd06ff57bc8bf2f7a22845110238ecbc34cR1): A new line was added to this file to configure the web server for production. This line specifies that the server should run the `serve` command with the production environment, listening on all IP addresses and on the port specified by the `PORT` environment variable.