### PR TITLE
added functionality to quickcreate

### DIFF
--- a/UpkeepiOS/Upkeep.xcodeproj/project.pbxproj
+++ b/UpkeepiOS/Upkeep.xcodeproj/project.pbxproj
@@ -31,9 +31,9 @@
 		A01FF5602BE4CBBA005A5F63 /* DefaultSymbols.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01FF55F2BE4CBBA005A5F63 /* DefaultSymbols.swift */; };
 		A01FF5612BE4CBBA005A5F63 /* DefaultSymbols.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01FF55F2BE4CBBA005A5F63 /* DefaultSymbols.swift */; };
 		A01FF5622BE4CBBA005A5F63 /* DefaultSymbols.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01FF55F2BE4CBBA005A5F63 /* DefaultSymbols.swift */; };
-		A01FF5652BE4CC08005A5F63 /* ManualEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01FF5632BE4CC08005A5F63 /* ManualEditor.swift */; };
-		A01FF5662BE4CC08005A5F63 /* ManualEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01FF5632BE4CC08005A5F63 /* ManualEditor.swift */; };
-		A01FF5672BE4CC08005A5F63 /* ManualEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01FF5632BE4CC08005A5F63 /* ManualEditor.swift */; };
+		A01FF5652BE4CC08005A5F63 /* ManualDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01FF5632BE4CC08005A5F63 /* ManualDetail.swift */; };
+		A01FF5662BE4CC08005A5F63 /* ManualDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01FF5632BE4CC08005A5F63 /* ManualDetail.swift */; };
+		A01FF5672BE4CC08005A5F63 /* ManualDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01FF5632BE4CC08005A5F63 /* ManualDetail.swift */; };
 		A01FF5682BE4CC08005A5F63 /* ManualItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01FF5642BE4CC08005A5F63 /* ManualItem.swift */; };
 		A01FF5692BE4CC08005A5F63 /* ManualItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01FF5642BE4CC08005A5F63 /* ManualItem.swift */; };
 		A01FF56A2BE4CC08005A5F63 /* ManualItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01FF5642BE4CC08005A5F63 /* ManualItem.swift */; };
@@ -87,19 +87,19 @@
 		A04ED5D52BD72639007703DD /* UpkeepUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ED5D42BD72639007703DD /* UpkeepUITests.swift */; };
 		A04ED5D72BD72639007703DD /* UpkeepUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ED5D62BD72639007703DD /* UpkeepUITestsLaunchTests.swift */; };
 		A04ED5EE2BD73E36007703DD /* Manual.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ED5ED2BD73E36007703DD /* Manual.swift */; };
-		A04ED5F02BDC402B007703DD /* Gallery.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ED5EF2BDC402B007703DD /* Gallery.swift */; };
-		A04ED5F42BDC644B007703DD /* Detail.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ED5F32BDC644B007703DD /* Detail.swift */; };
+		A04ED5F02BDC402B007703DD /* ApplianceGallery.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ED5EF2BDC402B007703DD /* ApplianceGallery.swift */; };
+		A04ED5F42BDC644B007703DD /* ApplianceDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ED5F32BDC644B007703DD /* ApplianceDetail.swift */; };
 		A04ED5FF2BDEE800007703DD /* Manual.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ED5ED2BD73E36007703DD /* Manual.swift */; };
 		A04ED6002BDEE800007703DD /* Manual.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ED5ED2BD73E36007703DD /* Manual.swift */; };
-		A04ED6012BDEF99C007703DD /* Gallery.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ED5EF2BDC402B007703DD /* Gallery.swift */; };
-		A04ED6022BDEF99C007703DD /* Gallery.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ED5EF2BDC402B007703DD /* Gallery.swift */; };
-		A04ED6032BDEF9A1007703DD /* Detail.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ED5F32BDC644B007703DD /* Detail.swift */; };
-		A04ED6042BDEF9A1007703DD /* Detail.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ED5F32BDC644B007703DD /* Detail.swift */; };
+		A04ED6012BDEF99C007703DD /* ApplianceGallery.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ED5EF2BDC402B007703DD /* ApplianceGallery.swift */; };
+		A04ED6022BDEF99C007703DD /* ApplianceGallery.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ED5EF2BDC402B007703DD /* ApplianceGallery.swift */; };
+		A04ED6032BDEF9A1007703DD /* ApplianceDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ED5F32BDC644B007703DD /* ApplianceDetail.swift */; };
+		A04ED6042BDEF9A1007703DD /* ApplianceDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ED5F32BDC644B007703DD /* ApplianceDetail.swift */; };
 		A04ED6072BDEF9A7007703DD /* Home.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ED5B92BD72635007703DD /* Home.swift */; };
 		A04ED6082BDEF9A7007703DD /* Home.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ED5B92BD72635007703DD /* Home.swift */; };
-		A04ED60A2BDEFB09007703DD /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ED6092BDEFB09007703DD /* Item.swift */; };
-		A04ED60B2BDEFB15007703DD /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ED6092BDEFB09007703DD /* Item.swift */; };
-		A04ED60C2BDEFB15007703DD /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ED6092BDEFB09007703DD /* Item.swift */; };
+		A04ED60A2BDEFB09007703DD /* ApplianceGalleryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ED6092BDEFB09007703DD /* ApplianceGalleryItem.swift */; };
+		A04ED60B2BDEFB15007703DD /* ApplianceGalleryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ED6092BDEFB09007703DD /* ApplianceGalleryItem.swift */; };
+		A04ED60C2BDEFB15007703DD /* ApplianceGalleryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ED6092BDEFB09007703DD /* ApplianceGalleryItem.swift */; };
 		A04ED60E2BDF21AE007703DD /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ED60D2BDF21AE007703DD /* WebView.swift */; };
 		A04ED60F2BDF21E5007703DD /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ED60D2BDF21AE007703DD /* WebView.swift */; };
 		A04ED6102BDF21E6007703DD /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ED60D2BDF21AE007703DD /* WebView.swift */; };
@@ -145,7 +145,7 @@
 		A01FF5572BE4CB96005A5F63 /* DefaultCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultCategory.swift; sourceTree = "<group>"; };
 		A01FF55B2BE4CBA7005A5F63 /* DefaultBrand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrand.swift; sourceTree = "<group>"; };
 		A01FF55F2BE4CBBA005A5F63 /* DefaultSymbols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSymbols.swift; sourceTree = "<group>"; };
-		A01FF5632BE4CC08005A5F63 /* ManualEditor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManualEditor.swift; sourceTree = "<group>"; };
+		A01FF5632BE4CC08005A5F63 /* ManualDetail.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManualDetail.swift; sourceTree = "<group>"; };
 		A01FF5642BE4CC08005A5F63 /* ManualItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManualItem.swift; sourceTree = "<group>"; };
 		A01FF56C2BE536AC005A5F63 /* Brand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Brand.swift; sourceTree = "<group>"; };
 		A01FF5702BE536B2005A5F63 /* Category.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
@@ -172,9 +172,9 @@
 		A04ED5D42BD72639007703DD /* UpkeepUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpkeepUITests.swift; sourceTree = "<group>"; };
 		A04ED5D62BD72639007703DD /* UpkeepUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpkeepUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		A04ED5ED2BD73E36007703DD /* Manual.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Manual.swift; sourceTree = "<group>"; };
-		A04ED5EF2BDC402B007703DD /* Gallery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Gallery.swift; sourceTree = "<group>"; };
-		A04ED5F32BDC644B007703DD /* Detail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Detail.swift; sourceTree = "<group>"; };
-		A04ED6092BDEFB09007703DD /* Item.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Item.swift; sourceTree = "<group>"; };
+		A04ED5EF2BDC402B007703DD /* ApplianceGallery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplianceGallery.swift; sourceTree = "<group>"; };
+		A04ED5F32BDC644B007703DD /* ApplianceDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplianceDetail.swift; sourceTree = "<group>"; };
+		A04ED6092BDEFB09007703DD /* ApplianceGalleryItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplianceGalleryItem.swift; sourceTree = "<group>"; };
 		A04ED60D2BDF21AE007703DD /* WebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
 		A04ED6152BDF222A007703DD /* PDFKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFKit.swift; sourceTree = "<group>"; };
 		A04ED6192BDF2246007703DD /* Browser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Browser.swift; sourceTree = "<group>"; };
@@ -210,9 +210,9 @@
 		A01FF54D2BE4CA4D005A5F63 /* Appliance */ = {
 			isa = PBXGroup;
 			children = (
-				A04ED5F32BDC644B007703DD /* Detail.swift */,
-				A04ED5EF2BDC402B007703DD /* Gallery.swift */,
-				A04ED6092BDEFB09007703DD /* Item.swift */,
+				A04ED5F32BDC644B007703DD /* ApplianceDetail.swift */,
+				A04ED5EF2BDC402B007703DD /* ApplianceGallery.swift */,
+				A04ED6092BDEFB09007703DD /* ApplianceGalleryItem.swift */,
 			);
 			path = Appliance;
 			sourceTree = "<group>";
@@ -280,7 +280,7 @@
 		A01FF56B2BE4CC22005A5F63 /* Manual */ = {
 			isa = PBXGroup;
 			children = (
-				A01FF5632BE4CC08005A5F63 /* ManualEditor.swift */,
+				A01FF5632BE4CC08005A5F63 /* ManualDetail.swift */,
 				A01FF5642BE4CC08005A5F63 /* ManualItem.swift */,
 			);
 			path = Manual;
@@ -511,13 +511,13 @@
 				A01FF5462BE48623005A5F63 /* DismissButton.swift in Sources */,
 				A01FF55C2BE4CBA7005A5F63 /* DefaultBrand.swift in Sources */,
 				A01FF57B2BE55F19005A5F63 /* Settings.swift in Sources */,
-				A04ED60A2BDEFB09007703DD /* Item.swift in Sources */,
+				A04ED60A2BDEFB09007703DD /* ApplianceGalleryItem.swift in Sources */,
 				A02CFFAA2BE1987F0086B93B /* SymbolPicker.swift in Sources */,
 				A04ED6222BDF2505007703DD /* Upkeep+Ext.swift in Sources */,
 				A01FF5852BE5ACB8005A5F63 /* FilterController.swift in Sources */,
 				A01FF5752BE536E3005A5F63 /* Appliance.swift in Sources */,
 				A04ED5BA2BD72635007703DD /* Home.swift in Sources */,
-				A04ED5F42BDC644B007703DD /* Detail.swift in Sources */,
+				A04ED5F42BDC644B007703DD /* ApplianceDetail.swift in Sources */,
 				A01FF5582BE4CB96005A5F63 /* DefaultCategory.swift in Sources */,
 				A02CFFCE2BE3EFC80086B93B /* ConditionalView+Generic.swift in Sources */,
 				A02CFFB22BE1F7110086B93B /* ToggleDatePicker.swift in Sources */,
@@ -535,11 +535,11 @@
 				A02CFFB62BE1F7200086B93B /* ToggleTextField.swift in Sources */,
 				A02CFFAE2BE1F7010086B93B /* SymbolPickerButton.swift in Sources */,
 				A01FF54A2BE4A39B005A5F63 /* Environment.swift in Sources */,
-				A01FF5652BE4CC08005A5F63 /* ManualEditor.swift in Sources */,
+				A01FF5652BE4CC08005A5F63 /* ManualDetail.swift in Sources */,
 				A01FF5422BE4795A005A5F63 /* QuickCreate.swift in Sources */,
 				A01FF5602BE4CBBA005A5F63 /* DefaultSymbols.swift in Sources */,
 				A04ED61E2BDF2375007703DD /* PDFViewer.swift in Sources */,
-				A04ED5F02BDC402B007703DD /* Gallery.swift in Sources */,
+				A04ED5F02BDC402B007703DD /* ApplianceGallery.swift in Sources */,
 				A01FF5712BE536B2005A5F63 /* Category.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -550,7 +550,7 @@
 			files = (
 				A04ED5FF2BDEE800007703DD /* Manual.swift in Sources */,
 				A01FF5592BE4CB96005A5F63 /* DefaultCategory.swift in Sources */,
-				A04ED60B2BDEFB15007703DD /* Item.swift in Sources */,
+				A04ED60B2BDEFB15007703DD /* ApplianceGalleryItem.swift in Sources */,
 				A02CFFCB2BE3201C0086B93B /* ToggleButton.swift in Sources */,
 				A01FF5882BE5B956005A5F63 /* Copy.swift in Sources */,
 				A02CFFAB2BE1987F0086B93B /* SymbolPicker.swift in Sources */,
@@ -569,11 +569,11 @@
 				A01FF56E2BE536AC005A5F63 /* Brand.swift in Sources */,
 				A01FF5432BE4795A005A5F63 /* QuickCreate.swift in Sources */,
 				A01FF53F2BE473AC005A5F63 /* WebServiceController.swift in Sources */,
-				A04ED6032BDEF9A1007703DD /* Detail.swift in Sources */,
+				A04ED6032BDEF9A1007703DD /* ApplianceDetail.swift in Sources */,
 				A04ED6172BDF222A007703DD /* PDFKit.swift in Sources */,
 				A01FF54B2BE4A531005A5F63 /* Environment.swift in Sources */,
 				A01FF5552BE4CB74005A5F63 /* ApplianceEnumProtocol.swift in Sources */,
-				A04ED6022BDEF99C007703DD /* Gallery.swift in Sources */,
+				A04ED6022BDEF99C007703DD /* ApplianceGallery.swift in Sources */,
 				A04ED61B2BDF2246007703DD /* Browser.swift in Sources */,
 				A02CFFB32BE1F7110086B93B /* ToggleDatePicker.swift in Sources */,
 				A04ED60F2BDF21E5007703DD /* WebView.swift in Sources */,
@@ -583,7 +583,7 @@
 				A01FF5472BE48623005A5F63 /* DismissButton.swift in Sources */,
 				A04ED61F2BDF2375007703DD /* PDFViewer.swift in Sources */,
 				A04ED6072BDEF9A7007703DD /* Home.swift in Sources */,
-				A01FF5662BE4CC08005A5F63 /* ManualEditor.swift in Sources */,
+				A01FF5662BE4CC08005A5F63 /* ManualDetail.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -600,7 +600,7 @@
 				A01FF5732BE536B2005A5F63 /* Category.swift in Sources */,
 				A04ED6242BDF2505007703DD /* Upkeep+Ext.swift in Sources */,
 				A04ED6102BDF21E6007703DD /* WebView.swift in Sources */,
-				A04ED60C2BDEFB15007703DD /* Item.swift in Sources */,
+				A04ED60C2BDEFB15007703DD /* ApplianceGalleryItem.swift in Sources */,
 				A04ED5D72BD72639007703DD /* UpkeepUITestsLaunchTests.swift in Sources */,
 				A02CFFAC2BE1987F0086B93B /* SymbolPicker.swift in Sources */,
 				A02CFFBC2BE1F7390086B93B /* TogglePickers.swift in Sources */,
@@ -614,16 +614,16 @@
 				A01FF56F2BE536AC005A5F63 /* Brand.swift in Sources */,
 				A01FF5482BE48623005A5F63 /* DismissButton.swift in Sources */,
 				A04ED6182BDF222A007703DD /* PDFKit.swift in Sources */,
-				A01FF5672BE4CC08005A5F63 /* ManualEditor.swift in Sources */,
+				A01FF5672BE4CC08005A5F63 /* ManualDetail.swift in Sources */,
 				A01FF5772BE536E3005A5F63 /* Appliance.swift in Sources */,
 				A01FF5562BE4CB74005A5F63 /* ApplianceEnumProtocol.swift in Sources */,
 				A02CFFB82BE1F7210086B93B /* ToggleTextField.swift in Sources */,
 				A01FF5622BE4CBBA005A5F63 /* DefaultSymbols.swift in Sources */,
-				A04ED6042BDEF9A1007703DD /* Detail.swift in Sources */,
+				A04ED6042BDEF9A1007703DD /* ApplianceDetail.swift in Sources */,
 				A01FF55A2BE4CB96005A5F63 /* DefaultCategory.swift in Sources */,
 				A04ED61C2BDF2246007703DD /* Browser.swift in Sources */,
 				A01FF5892BE5B956005A5F63 /* Copy.swift in Sources */,
-				A04ED6012BDEF99C007703DD /* Gallery.swift in Sources */,
+				A04ED6012BDEF99C007703DD /* ApplianceGallery.swift in Sources */,
 				A04ED6082BDEF9A7007703DD /* Home.swift in Sources */,
 				A04ED6202BDF2375007703DD /* PDFViewer.swift in Sources */,
 				A04ED6002BDEE800007703DD /* Manual.swift in Sources */,

--- a/UpkeepiOS/Upkeep/Appliance/ApplianceGallery.swift
+++ b/UpkeepiOS/Upkeep/Appliance/ApplianceGallery.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftData
 import SwiftUI
 
-struct Gallery: View {
+struct ApplianceGallery: View {
     @Environment(\.modelContext) private var modelContext
     @State private var filteredAppliances: [Appliance] = []
     @State private var selectedAppliance: Appliance?
@@ -31,9 +31,9 @@ struct Gallery: View {
         List {
             ForEach(filteredAppliances) { appliance in
                 NavigationLink {
-                    Detail(appliance: appliance, modelType: .existing)
+                    ApplianceDetail(appliance: appliance, modelType: .existing)
                 } label: {
-                    Item(appliance: appliance)
+                    ApplianceGalleryItem(appliance: appliance)
                 }
             }
             .onDelete(perform: deleteAppliance)
@@ -57,7 +57,7 @@ struct Gallery: View {
                 QuickCreate(appliance: $newAppliance)
             }
             .sheet(item: $newAppliance, content: { appliance in
-                Detail(appliance: appliance, modelType: .new)
+                ApplianceDetail(appliance: appliance, modelType: .new)
             })
         }
     }

--- a/UpkeepiOS/Upkeep/Appliance/ApplianceGalleryItem.swift
+++ b/UpkeepiOS/Upkeep/Appliance/ApplianceGalleryItem.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftData
 import SwiftUI
 
-struct ItemSymbol: View {
+struct ApplianceGalleryItemSymbol: View {
     @Bindable var appliance: Appliance
 
     var body: some View {
@@ -28,13 +28,13 @@ struct ItemSymbol: View {
     }
 }
 
-struct Item: View {
+struct ApplianceGalleryItem: View {
     @Environment(\.modelContext) var modelContext
     @Bindable var appliance: Appliance
 
     var body: some View {
         HStack(spacing: 20) {
-            ItemSymbol(appliance: appliance)
+            ApplianceGalleryItemSymbol(appliance: appliance)
 
             VStack(alignment: .leading) {
                 Text(appliance.brand?.name ?? "No Name")

--- a/UpkeepiOS/Upkeep/Components/Browser.swift
+++ b/UpkeepiOS/Upkeep/Components/Browser.swift
@@ -14,6 +14,7 @@ struct Browser: View {
     @Environment(\.dismiss) var dismissAction
     @Environment(\.modelContext) var modelContext
     @State private var newManual: Manual?
+    @Bindable var appliance: Appliance
     let baseURL: URL
 
     var body: some View {
@@ -26,11 +27,13 @@ struct Browser: View {
             }
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
-                    DismissButton()
+                    Button("Close") {
+                        dismissAction()
+                    }
                 }
             }
             .sheet(item: $newManual, content: {
-                ManualEditor(manual: $0)
+                ManualDetail(manual: $0, appliance: appliance)
             })
         }
     }

--- a/UpkeepiOS/Upkeep/Components/QuickCreate.swift
+++ b/UpkeepiOS/Upkeep/Components/QuickCreate.swift
@@ -8,6 +8,18 @@
 import SwiftData
 import SwiftUI
 
+struct AppliancePropertyCarrier: Identifiable {
+    let id = UUID().uuidString
+    var name: String = .none
+    var category: Category?
+    var brand: Brand?
+    var modelNumber: String = .none
+    var serialNumber: String = .none
+    var purchaseDate: Date = .now
+    var warrantyExpirationDate: Date = .now
+    var lastMaintenaceDate: Date = .now
+}
+
 struct QuickCreate: View {
     @Binding var appliance: Appliance?
 
@@ -15,17 +27,8 @@ struct QuickCreate: View {
     @Environment(\.modelContext) var modelContext
     @Environment(\.editMode) var editMode
 
-    @State private var applianceBrand: Brand?
-    @State private var modelNumber = String.none
+    @State var carrier = AppliancePropertyCarrier()
     @State private var searchInProgress = false
-    @State private var applianceCategory: Category?
-    @State private var applianceSymbol: DefaultSymbols = .wrenchAndScrewdriverFill
-    @State private var serialNumber = String.none
-    @State private var lastMaintenanceDate = Date()
-    @State private var purchaseDate = Date()
-    @State private var warrantyExpirationDate = Date()
-    @State private var isExpanded = false
-    @State private var isEditing: EditMode = .active
 
     @Query(sort: \Brand.name) var brands: [Brand]
 
@@ -33,49 +36,40 @@ struct QuickCreate: View {
         NavigationStack {
             List {
                 Section {
-                    TextField(Copy.QuickCreate.modelNumberPrompt, text: $modelNumber)
+                    TextField(Copy.QuickCreate.modelNumberPrompt, text: $carrier.modelNumber)
 
                     LabeledContent(Copy.QuickCreate.brandPickerMenuLabel) {
-                        Menu(applianceBrand?.name ?? Copy.QuickCreate.brandPickerPlaceholder) {
+                        Menu(carrier.brand?.name ?? Copy.QuickCreate.brandPickerPlaceholder) {
                             ForEach(brands, id: \.rawValue) { b in
                                 Button(b.name) {
-                                    applianceBrand = b
+                                    carrier.brand = b
                                 }.tag(b)
                             }
                         }
                     }
                 }
 
-                Button("Advanced") {
-                    withAnimation {
-                        isExpanded.toggle()
-                        isEditing = isExpanded ? .active : .inactive
+                Section("Advanced") {
+                    // Category toggle picker
+                    LabeledContent(Copy.Appliance.typeLabel) {
+                        CategoryTogglePicker(selection: $carrier.category)
                     }
-                }
 
-                if isExpanded {
-                    Section {
-                        // Category toggle picker
-                        LabeledContent(Copy.Appliance.typeLabel) {
-                            CategoryTogglePicker(selection: $applianceCategory)
-                        }
+                    LabeledContent(Copy.Appliance.serialNumberLabel) {
+                        ToggleTextField(text: $carrier.serialNumber)
+                    }
 
-                        LabeledContent(Copy.Appliance.serialNumberLabel) {
-                            ToggleTextField(text: $serialNumber)
-                        }
-
-                        // Dates related to appliance maintenance and warranty
-                        LabeledContent(Copy.Appliance.lastMaintenanceLabel) {
-                            ToggleDatePicker(selection: $lastMaintenanceDate)
-                        }
-                        LabeledContent(Copy.Appliance.purchasedDateLabel) {
-                            ToggleDatePicker(selection: $purchaseDate)
-                        }
-                        LabeledContent(Copy.Appliance.warrantyExpirationLabel) {
-                            ToggleDatePicker(selection: $warrantyExpirationDate)
-                        }
-                    }.environment(\.editMode, $isEditing)
-                }
+                    // Dates related to appliance maintenance and warranty
+                    LabeledContent(Copy.Appliance.lastMaintenanceLabel) {
+                        ToggleDatePicker(selection: $carrier.lastMaintenaceDate)
+                    }
+                    LabeledContent(Copy.Appliance.purchasedDateLabel) {
+                        ToggleDatePicker(selection: $carrier.purchaseDate)
+                    }
+                    LabeledContent(Copy.Appliance.warrantyExpirationLabel) {
+                        ToggleDatePicker(selection: $carrier.warrantyExpirationDate)
+                    }
+                }.environment(\.editMode, .constant(.active))
             }
             .navigationTitle("Quick Create")
             .toolbar {
@@ -118,23 +112,34 @@ struct QuickCreate: View {
         ToolbarItem(placement: .primaryAction, content: {
             Button(Copy.QuickCreate.searchModelLabel, systemImage: Copy.QuickCreate.searchModelSymbol, action: {
                 searchInProgress = true
-            }).disabled(modelNumber.isEmpty || applianceBrand == nil)
+            }).disabled(carrier.modelNumber.isEmpty || carrier.brand == nil)
         })
     }
 
     @MainActor
     func queryWebService() async {
-        guard let brand = appliance?.brand else {
+        guard let brand = carrier.brand else {
             return
         }
 
-        guard let obj = await WebServiceController(modelContext: modelContext).fetchAppliance(brand: brand, modelNumber: modelNumber) else {
+        guard let obj = await WebServiceController(modelContext: modelContext).fetchAppliance(brand: brand, modelNumber: carrier.modelNumber) else {
             appliance = nil
             return
         }
 
         searchInProgress = false
+
+        obj.serialNumber = carrier.serialNumber
+        obj.lastMaintenaceDate = carrier.lastMaintenaceDate
+        obj.purchaseDate = carrier.purchaseDate
+        obj.warrantyExpirationDate = carrier.warrantyExpirationDate
+
+        if let category = carrier.category {
+            obj.category = category
+        }
+
         appliance = obj
+        dismiss()
     }
 
     @MainActor

--- a/UpkeepiOS/Upkeep/Components/ToggleTextField.swift
+++ b/UpkeepiOS/Upkeep/Components/ToggleTextField.swift
@@ -13,7 +13,7 @@ struct ToggleTextField: View {
     @Environment(\.editMode) var editMode
 
     var body: some View {
-        Text(text)
+        Text(text.isEmpty ? "--" : text)
             .if(editMode?.wrappedValue.isEditing == true) { _ in
                 TextField("00000000", text: $text)
                     .multilineTextAlignment(.trailing)

--- a/UpkeepiOS/Upkeep/Home.swift
+++ b/UpkeepiOS/Upkeep/Home.swift
@@ -1,5 +1,5 @@
 //
-//  ContentView.swift
+//  Home.swift
 //  Upkeep
 //
 //  Created by Mustafa on 4/22/24.
@@ -15,7 +15,7 @@ struct Home: View {
     var body: some View {
         TabView {
             // Appliance gallery
-            Gallery()
+            ApplianceGallery()
                 .tabItem {
                     Label("Appliances", systemImage: "refrigerator")
                         .environment(\.symbolVariants, .none)

--- a/UpkeepiOS/Upkeep/Manual/ManualDetail.swift
+++ b/UpkeepiOS/Upkeep/Manual/ManualDetail.swift
@@ -9,11 +9,12 @@ import Foundation
 import SwiftData
 import SwiftUI
 
-struct ManualEditor: View {
+struct ManualDetail: View {
     @Environment(\.modelContext) var modelContext
     @Environment(\.dismiss) var dismissAction
     @Query var appliances: [Appliance]
     @Bindable var manual: Manual
+    @Bindable var appliance: Appliance
 
     var body: some View {
         NavigationStack {
@@ -53,6 +54,11 @@ struct ManualEditor: View {
                 }
             }
         }
+        .onAppear {
+            if manual.appliance == nil {
+                manual.appliance = appliance
+            }
+        }
     }
 }
 
@@ -62,6 +68,6 @@ struct ManualEditor: View {
     container.mainContext.insert(app)
     let manual = Manual(name: String.none, urlString: "https://data2.manualslib.com/pdf7/302/30121/3012079-kitchenaid/krff507hps.pdf?5c7cf92795281981af25aec0224b3a20", file: try! Data(contentsOf: URL(string: "https://data2.manualslib.com/pdf7/302/30121/3012079-kitchenaid/krff507hps.pdf?5c7cf92795281981af25aec0224b3a20")!))
     container.mainContext.insert(manual)
-    return ManualEditor(manual: manual)
+    return ManualDetail(manual: manual, appliance: app)
         .modelContainer(container)
 }

--- a/UpkeepiOS/Upkeep/Manual/ManualItem.swift
+++ b/UpkeepiOS/Upkeep/Manual/ManualItem.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct ManualItem: View {
     @Environment(\.modelContext) var modelContext
     @Bindable var manual: Manual
+    @Bindable var appliance: Appliance
     @State var selectedManual: Manual?
     @State var editingManual: Manual?
 
@@ -20,14 +21,16 @@ struct ManualItem: View {
         }
         .lineLimit(1)
         .sheet(item: $editingManual, content: {
-            ManualEditor(manual: $0)
+            ManualDetail(manual: $0, appliance: appliance)
         })
         .fullScreenCover(item: $selectedManual, content: {
             PDFViewer(manual: $0)
         })
         .swipeActions(edge: .trailing) {
             Button("Delete", systemImage: "trash") {
-                modelContext.delete(manual)
+                withAnimation {
+                    modelContext.delete(manual)
+                }
             }.tint(.red)
         }
         .contextMenu {

--- a/UpkeepiOS/Upkeep/Settings.swift
+++ b/UpkeepiOS/Upkeep/Settings.swift
@@ -10,8 +10,10 @@ import SwiftUI
 struct Settings: View {
     var body: some View {
         NavigationStack {
-            Text("Not yet implemented!")
-                .navigationTitle(Copy.Settings.pageTitle)
+            List {
+                Toggle("Disable AI Search", isOn: .constant(false)).disabled(true)
+            }
+            .navigationTitle(Copy.Settings.pageTitle)
         }
     }
 }


### PR DESCRIPTION
This pull request includes changes to the `UpkeepiOS/Upkeep.xcodeproj/project.pbxproj` and several Swift files in the `UpkeepiOS/Upkeep/Appliance` directory. The changes involve renaming and modifying several Swift files and updating references to these files in the Xcode project file. The Swift files affected are related to the `Appliance` feature of the application.

Changes to Swift files:

* `UpkeepiOS/Upkeep/Appliance/Detail.swift` was renamed to `ApplianceDetail.swift` and its main struct was renamed from `Detail` to `ApplianceDetail`. The symbol picker was disabled when not in edit mode and the navigation bar title display mode was changed from large to inline. A new section was added for a button to browse and save manuals online. [[1]](diffhunk://#diff-2e7f0c565d3e3299c914241f1586ca8154b464df9a39986d1dbe03acf9422b61L12-R12) [[2]](diffhunk://#diff-2e7f0c565d3e3299c914241f1586ca8154b464df9a39986d1dbe03acf9422b61R84) [[3]](diffhunk://#diff-2e7f0c565d3e3299c914241f1586ca8154b464df9a39986d1dbe03acf9422b61L123-R165)
* `UpkeepiOS/Upkeep/Appliance/Gallery.swift` was renamed to `ApplianceGallery.swift` and its main struct was renamed from `Gallery` to `ApplianceGallery`. The navigation link was updated to use `ApplianceDetail` and `ApplianceGalleryItem`. [[1]](diffhunk://#diff-bb13e7c72410d35ed5cc5ec3818a6842e7ea2a6eb9a3229d76fa034b37d75811L12-R12) [[2]](diffhunk://#diff-bb13e7c72410d35ed5cc5ec3818a6842e7ea2a6eb9a3229d76fa034b37d75811L34-R36)

Changes to Xcode project file:

* The references to the Swift files `Detail.swift`, `Gallery.swift`, `Item.swift`, and `ManualEditor.swift` were updated to `ApplianceDetail.swift`, `ApplianceGallery.swift`, `ApplianceGalleryItem.swift`, and `ManualDetail.swift`, respectively. [[1]](diffhunk://#diff-b07a76abfeb9267666017753c9f63d4c741b81f1ab472f80d40e750a142adaffL34-R36) [[2]](diffhunk://#diff-b07a76abfeb9267666017753c9f63d4c741b81f1ab472f80d40e750a142adaffL90-R102) [[3]](diffhunk://#diff-b07a76abfeb9267666017753c9f63d4c741b81f1ab472f80d40e750a142adaffL148-R148) [[4]](diffhunk://#diff-b07a76abfeb9267666017753c9f63d4c741b81f1ab472f80d40e750a142adaffL175-R177) [[5]](diffhunk://#diff-b07a76abfeb9267666017753c9f63d4c741b81f1ab472f80d40e750a142adaffL213-R215) [[6]](diffhunk://#diff-b07a76abfeb9267666017753c9f63d4c741b81f1ab472f80d40e750a142adaffL283-R283) [[7]](diffhunk://#diff-b07a76abfeb9267666017753c9f63d4c741b81f1ab472f80d40e750a142adaffL514-R520) [[8]](diffhunk://#diff-b07a76abfeb9267666017753c9f63d4c741b81f1ab472f80d40e750a142adaffL538-R542) [[9]](diffhunk://#diff-b07a76abfeb9267666017753c9f63d4c741b81f1ab472f80d40e750a142adaffL553-R553) [[10]](diffhunk://#diff-b07a76abfeb9267666017753c9f63d4c741b81f1ab472f80d40e750a142adaffL572-R576) [[11]](diffhunk://#diff-b07a76abfeb9267666017753c9f63d4c741b81f1ab472f80d40e750a142adaffL586-R586) [[12]](diffhunk://#diff-b07a76abfeb9267666017753c9f63d4c741b81f1ab472f80d40e750a142adaffL603-R603) [[13]](diffhunk://#diff-b07a76abfeb9267666017753c9f63d4c741b81f1ab472f80d40e750a142adaffL617-R626)