### PR TITLE
added tests for homeViewModel

### DIFF
--- a/UpkeepiOS/Upkeep.xcodeproj/project.pbxproj
+++ b/UpkeepiOS/Upkeep.xcodeproj/project.pbxproj
@@ -13,8 +13,8 @@
 		A01FF54A2BE4A39B005A5F63 /* EnvironmentValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01FF5492BE4A39B005A5F63 /* EnvironmentValues.swift */; };
 		A01FF5582BE4CB96005A5F63 /* DefaultCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01FF5572BE4CB96005A5F63 /* DefaultCategory.swift */; };
 		A01FF5592BE4CB96005A5F63 /* DefaultCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01FF5572BE4CB96005A5F63 /* DefaultCategory.swift */; };
-		A01FF55C2BE4CBA7005A5F63 /* DefaultBrand.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01FF55B2BE4CBA7005A5F63 /* DefaultBrand.swift */; };
-		A01FF55D2BE4CBA7005A5F63 /* DefaultBrand.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01FF55B2BE4CBA7005A5F63 /* DefaultBrand.swift */; };
+		A01FF55C2BE4CBA7005A5F63 /* DefaultBrands.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01FF55B2BE4CBA7005A5F63 /* DefaultBrands.swift */; };
+		A01FF55D2BE4CBA7005A5F63 /* DefaultBrands.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01FF55B2BE4CBA7005A5F63 /* DefaultBrands.swift */; };
 		A01FF5602BE4CBBA005A5F63 /* DefaultSymbols.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01FF55F2BE4CBBA005A5F63 /* DefaultSymbols.swift */; };
 		A01FF5612BE4CBBA005A5F63 /* DefaultSymbols.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01FF55F2BE4CBBA005A5F63 /* DefaultSymbols.swift */; };
 		A01FF5652BE4CC08005A5F63 /* ManualDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01FF5632BE4CC08005A5F63 /* ManualDetail.swift */; };
@@ -106,6 +106,7 @@
 		A0246E8F2BE9900B00AF459E /* Date+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0246E8D2BE9900B00AF459E /* Date+Ext.swift */; };
 		A0246ED82BE9A11E00AF459E /* LogManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0246ED72BE9A11E00AF459E /* LogManager.swift */; };
 		A0246ED92BE9C19A00AF459E /* LogManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0246ED72BE9A11E00AF459E /* LogManager.swift */; };
+		A0246EDB2BE9CD8300AF459E /* HomeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0246EDA2BE9CD8300AF459E /* HomeViewModelTests.swift */; };
 		A02CFFAA2BE1987F0086B93B /* SymbolPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A02CFFA92BE1987F0086B93B /* SymbolPicker.swift */; };
 		A02CFFAE2BE1F7010086B93B /* SymbolPickerButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A02CFFAD2BE1F7010086B93B /* SymbolPickerButton.swift */; };
 		A02CFFC22BE2FE9B0086B93B /* FilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A02CFFC12BE2FE9B0086B93B /* FilterView.swift */; };
@@ -141,7 +142,7 @@
 		A01FF5412BE4795A005A5F63 /* GalleryQuickCreateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryQuickCreateView.swift; sourceTree = "<group>"; };
 		A01FF5492BE4A39B005A5F63 /* EnvironmentValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentValues.swift; sourceTree = "<group>"; };
 		A01FF5572BE4CB96005A5F63 /* DefaultCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultCategory.swift; sourceTree = "<group>"; };
-		A01FF55B2BE4CBA7005A5F63 /* DefaultBrand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrand.swift; sourceTree = "<group>"; };
+		A01FF55B2BE4CBA7005A5F63 /* DefaultBrands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrands.swift; sourceTree = "<group>"; };
 		A01FF55F2BE4CBBA005A5F63 /* DefaultSymbols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSymbols.swift; sourceTree = "<group>"; };
 		A01FF5632BE4CC08005A5F63 /* ManualDetail.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManualDetail.swift; sourceTree = "<group>"; };
 		A01FF5642BE4CC08005A5F63 /* ManualItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManualItem.swift; sourceTree = "<group>"; };
@@ -182,6 +183,7 @@
 		A0246E8A2BE98FFB00AF459E /* String+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Ext.swift"; sourceTree = "<group>"; };
 		A0246E8D2BE9900B00AF459E /* Date+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Ext.swift"; sourceTree = "<group>"; };
 		A0246ED72BE9A11E00AF459E /* LogManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogManager.swift; sourceTree = "<group>"; };
+		A0246EDA2BE9CD8300AF459E /* HomeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModelTests.swift; sourceTree = "<group>"; };
 		A02CFFA92BE1987F0086B93B /* SymbolPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolPicker.swift; sourceTree = "<group>"; };
 		A02CFFAD2BE1F7010086B93B /* SymbolPickerButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolPickerButton.swift; sourceTree = "<group>"; };
 		A02CFFC12BE2FE9B0086B93B /* FilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterView.swift; sourceTree = "<group>"; };
@@ -272,7 +274,7 @@
 		A0246DF72BE86FE100AF459E /* Enums */ = {
 			isa = PBXGroup;
 			children = (
-				A01FF55B2BE4CBA7005A5F63 /* DefaultBrand.swift */,
+				A01FF55B2BE4CBA7005A5F63 /* DefaultBrands.swift */,
 				A01FF5572BE4CB96005A5F63 /* DefaultCategory.swift */,
 				A01FF55F2BE4CBBA005A5F63 /* DefaultSymbols.swift */,
 			);
@@ -547,6 +549,7 @@
 			isa = PBXGroup;
 			children = (
 				A04ED5CA2BD72639007703DD /* UpkeepTests.swift */,
+				A0246EDA2BE9CD8300AF459E /* HomeViewModelTests.swift */,
 			);
 			path = UpkeepTests;
 			sourceTree = "<group>";
@@ -658,7 +661,7 @@
 				A01FF5832BE5A854005A5F63 /* Copy.swift in Sources */,
 				A0246E502BE935D400AF459E /* ManualItemViewModel.swift in Sources */,
 				A0246E692BE9460F00AF459E /* ToggleButtonViewModel.swift in Sources */,
-				A01FF55C2BE4CBA7005A5F63 /* DefaultBrand.swift in Sources */,
+				A01FF55C2BE4CBA7005A5F63 /* DefaultBrands.swift in Sources */,
 				A01FF57B2BE55F19005A5F63 /* SettingsView.swift in Sources */,
 				A0246E8E2BE9900B00AF459E /* Date+Ext.swift in Sources */,
 				A02CFFAA2BE1987F0086B93B /* SymbolPicker.swift in Sources */,
@@ -721,6 +724,7 @@
 				A0246E362BE923EB00AF459E /* HomeViewModel.swift in Sources */,
 				A0246E2F2BE8825E00AF459E /* GalleryItemViewModel.swift in Sources */,
 				A01FF5762BE536E3005A5F63 /* Appliance.swift in Sources */,
+				A0246EDB2BE9CD8300AF459E /* HomeViewModelTests.swift in Sources */,
 				A0246E012BE8736F00AF459E /* ApplianceDetailView.swift in Sources */,
 				A0246E862BE98FD000AF459E /* View+Ext.swift in Sources */,
 				A0246E5C2BE941B600AF459E /* TogglePickerViewModel.swift in Sources */,
@@ -753,7 +757,7 @@
 				A0246E172BE8750100AF459E /* ApplianceProtocolCarrier.swift in Sources */,
 				A0246E702BE9465000AF459E /* ToggleTextFieldViewModel.swift in Sources */,
 				A0246E1E2BE87E1300AF459E /* GalleryViewModel.swift in Sources */,
-				A01FF55D2BE4CBA7005A5F63 /* DefaultBrand.swift in Sources */,
+				A01FF55D2BE4CBA7005A5F63 /* DefaultBrands.swift in Sources */,
 				A0D66B432BE152B90045AE66 /* UpkeepApp.swift in Sources */,
 				A0246E512BE935D400AF459E /* ManualItemViewModel.swift in Sources */,
 				A01FF5862BE5ACB8005A5F63 /* FilterManager.swift in Sources */,

--- a/UpkeepiOS/Upkeep/Core/Home/HomeViewModel.swift
+++ b/UpkeepiOS/Upkeep/Core/Home/HomeViewModel.swift
@@ -22,7 +22,7 @@ class HomeViewModel: ObservableObject {
 
     private func addDefaultsIfNeeded() {
         if modelContext.isEmpty {
-            for brand in DefaultBrand.allCases {
+            for brand in DefaultBrands.allCases {
                 modelContext.insert(Brand(name: brand.rawValue))
                 logger.logInfo("Added default brand: \(brand.rawValue)")
             }

--- a/UpkeepiOS/Upkeep/Extensions/ModelContext+Ext.swift
+++ b/UpkeepiOS/Upkeep/Extensions/ModelContext+Ext.swift
@@ -22,8 +22,7 @@ extension ModelContext {
 
 extension ModelContext {
     var isEmpty: Bool {
-        let itemFetchDescriptor = FetchDescriptor<Brand>()
-        guard (try? fetch(itemFetchDescriptor).count) == 0 else {
+        guard (try? fetchIdentifiers(FetchDescriptor<Brand>()).count) == 0 else {
             return false
         }
         return true

--- a/UpkeepiOS/Upkeep/Models/Enums/DefaultBrands.swift
+++ b/UpkeepiOS/Upkeep/Models/Enums/DefaultBrands.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum DefaultBrand: String, BrandProtocol, CaseIterable {
+enum DefaultBrands: String, BrandProtocol, CaseIterable {
     case samsung = "Samsung"
     case lg = "LG"
     case whirlpool = "Whirlpool"
@@ -210,7 +210,7 @@ enum DefaultBrand: String, BrandProtocol, CaseIterable {
     }
 }
 
-extension DefaultBrand: CodingKey {
+extension DefaultBrands: CodingKey {
     var stringValue: String {
         return rawValue.camelCase()
     }

--- a/UpkeepiOS/Upkeep/Models/SwiftData/Brand.swift
+++ b/UpkeepiOS/Upkeep/Models/SwiftData/Brand.swift
@@ -26,7 +26,7 @@ final class Brand: BrandProtocol {
     }
 
     var isDefaultBrand: Bool {
-        if DefaultBrand(rawValue: self.rawValue) != nil {
+        if DefaultBrands(rawValue: self.rawValue) != nil {
             return true
         } else {
             return false

--- a/UpkeepiOS/UpkeepTests/HomeViewModelTests.swift
+++ b/UpkeepiOS/UpkeepTests/HomeViewModelTests.swift
@@ -1,0 +1,49 @@
+//
+//  HomeViewModelTests.swift
+//  UpkeepTests
+//
+//  Created by Mustafa on 5/6/24.
+//
+
+import Combine
+import Foundation
+import SwiftData
+@testable import Upkeep
+import XCTest
+
+class HomeViewModelTests: XCTestCase {
+    var modelContext: ModelContext!
+    var viewModel: HomeViewModel!
+
+    @MainActor
+    override func setUp() {
+        super.setUp()
+        modelContext = try! ModelContainer(for: Appliance.self, Manual.self, Brand.self, Category.self, configurations: .init(isStoredInMemoryOnly: true)).mainContext
+        viewModel = HomeViewModel(modelContext: modelContext)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testHomeViewModel_Initialization_PopulatesAppliances() {
+        XCTAssert(viewModel.appliances.isEmpty, "Model context is be empty on first launch.")
+        modelContext.insert(Appliance())
+        viewModel = HomeViewModel(modelContext: modelContext)
+        XCTAssertEqual(viewModel.appliances.count, 1, "One appliance is in the view model.")
+    }
+
+    @MainActor
+    func testHomeViewModel_AddDefaultsIfNeeded_InsertsDefaultsWhenEmpty() {
+        modelContext = try! ModelContainer(for: Appliance.self, Manual.self, Brand.self, Category.self, configurations: .init(isStoredInMemoryOnly: true)).mainContext
+        XCTAssert(modelContext.isEmpty, "Model Context is empty")
+        viewModel = HomeViewModel(modelContext: modelContext)
+        XCTAssert(!modelContext.isEmpty, "Defaults were added")
+    }
+
+    func testHomeViewModel_AddDefaultsIfNeeded_SkipsInsertsWhenNotEmpty() {
+        let brands: [Brand] = modelContext.fetchData()
+        viewModel = HomeViewModel(modelContext: modelContext)
+        XCTAssertEqual(brands.count, DefaultBrands.allCases.count, "No new brands were added.")
+    }
+}


### PR DESCRIPTION
This pull request contains changes primarily focused on renaming `DefaultBrand` to `DefaultBrands` and adding a new test file `HomeViewModelTests.swift`. 

Renaming `DefaultBrand` to `DefaultBrands`:
* [`UpkeepiOS/Upkeep.xcodeproj/project.pbxproj`](diffhunk://#diff-b07a76abfeb9267666017753c9f63d4c741b81f1ab472f80d40e750a142adaffL16-R17): The file `DefaultBrand.swift` is renamed to `DefaultBrands.swift` in multiple places. [[1]](diffhunk://#diff-b07a76abfeb9267666017753c9f63d4c741b81f1ab472f80d40e750a142adaffL16-R17) [[2]](diffhunk://#diff-b07a76abfeb9267666017753c9f63d4c741b81f1ab472f80d40e750a142adaffL144-R145) [[3]](diffhunk://#diff-b07a76abfeb9267666017753c9f63d4c741b81f1ab472f80d40e750a142adaffL275-R277) [[4]](diffhunk://#diff-b07a76abfeb9267666017753c9f63d4c741b81f1ab472f80d40e750a142adaffL661-R664) [[5]](diffhunk://#diff-b07a76abfeb9267666017753c9f63d4c741b81f1ab472f80d40e750a142adaffL756-R760)
* [`UpkeepiOS/Upkeep/Core/Home/HomeViewModel.swift`](diffhunk://#diff-c59202fb35fd4d075ce1d9ffc5e891fc8c457f76583734b9939ac3d9500d17f4L25-R25): The enumeration `DefaultBrand` is replaced with `DefaultBrands` in `addDefaultsIfNeeded` method.
* [`UpkeepiOS/Upkeep/Models/Enums/DefaultBrands.swift`](diffhunk://#diff-2f0c41246b7370e2134a802bd881f4465b4bbea742516f42ad469ec073ed0562L10-R10): The enumeration `DefaultBrand` is renamed to `DefaultBrands` and its extension is updated accordingly. [[1]](diffhunk://#diff-2f0c41246b7370e2134a802bd881f4465b4bbea742516f42ad469ec073ed0562L10-R10) [[2]](diffhunk://#diff-2f0c41246b7370e2134a802bd881f4465b4bbea742516f42ad469ec073ed0562L213-R213)
* [`UpkeepiOS/Upkeep/Models/SwiftData/Brand.swift`](diffhunk://#diff-46934b06971c1a8aa956f66816aeef88a2fc840baa48578ba6b98bc5d66cadb8L29-R29): The method `isDefaultBrand` now checks for `DefaultBrands` instead of `DefaultBrand`.

Adding `HomeViewModelTests.swift`:
* [`UpkeepiOS/Upkeep.xcodeproj/project.pbxproj`](diffhunk://#diff-b07a76abfeb9267666017753c9f63d4c741b81f1ab472f80d40e750a142adaffR109): The file `HomeViewModelTests.swift` is added in multiple places. [[1]](diffhunk://#diff-b07a76abfeb9267666017753c9f63d4c741b81f1ab472f80d40e750a142adaffR109) [[2]](diffhunk://#diff-b07a76abfeb9267666017753c9f63d4c741b81f1ab472f80d40e750a142adaffR186) [[3]](diffhunk://#diff-b07a76abfeb9267666017753c9f63d4c741b81f1ab472f80d40e750a142adaffR552) [[4]](diffhunk://#diff-b07a76abfeb9267666017753c9f63d4c741b81f1ab472f80d40e750a142adaffR727)
* [`UpkeepiOS/UpkeepTests/HomeViewModelTests.swift`](diffhunk://#diff-01952ce39ce35c3afb12b9489a7eab57cb50193d889fa590fa963097e61a1f4dR1-R49): This new file contains tests for `HomeViewModel`.

Minor change:
* [`UpkeepiOS/Upkeep/Extensions/ModelContext+Ext.swift`](diffhunk://#diff-0f8830cfa6d8d65e51eb3f05ef5add4824fd3c25a548ad79df48ecb2ba19c07dL25-R25): The `isEmpty` method is updated to use `fetchIdentifiers` instead of `fetch`.